### PR TITLE
Refactor `compute_fermi_energy` for adaptive kgrid

### DIFF
--- a/docs/literate/examples/fermi_energy.jl
+++ b/docs/literate/examples/fermi_energy.jl
@@ -17,7 +17,7 @@ kbT = 0.01  # eV
 # For NoneSmearing, usually need a larger tolerance, otherwise cannot bisect Fermi energy
 # smearing = Wannier.NoneSmearing()
 # tol_n_electrons = 1e-4
-# εF, adpt_kgrid = Wannier.compute_fermi_energy(interp, kgrid, num_electrons, kbT, smearing, tol_n_electrons)
+# εF, adpt_kgrid = Wannier.compute_fermi_energy(kgrid, interp, num_electrons, kbT, smearing, tol_n_electrons)
 
 n_electrons = 8
 # This is a TB Hamiltonian from a SOC calculation
@@ -26,9 +26,27 @@ prefactor = 1
 # smearing = Wannier.FermiDiracSmearing()
 smearing = Wannier.ColdSmearing()
 tol_εF = 5e-3  # convergence tolerance for Fermi energy in eV
-εF, adpt_kgrid = Wannier.compute_fermi_energy(
-    interp, kgrid, n_electrons, kbT, smearing; prefactor, tol_εF
+
+# You can directly compute Fermi energy by
+εF = Wannier.compute_fermi_energy(
+    kgrid, interp, n_electrons, kbT, smearing; prefactor, tol_εF
 )
+
+# But here we will separate it into two steps, 1st construct the adaptive kgrid,
+# which is actually a uniformlly-spaced grid on input, but the [`AdaptiveKgrid`](@ref)
+# data structure allows it to be iteratively refined on selected kpoints later on.
+adpt_kgrid = Wannier.AdaptiveKgrid(kgrid, interp)
+# then compute Fermi energy
+εF = Wannier.compute_fermi_energy!(
+    adpt_kgrid, interp, n_electrons, kbT, smearing; prefactor, tol_εF
+)
+# The `Wannier.compute_fermi_energy!` function is a lower-level function,
+# will modify the input `adpt_kgrid`, and from `adpt_kgrid` we can retrieve
+# all the interpolated eigenvalues that are used to compute Fermi energy.
+# For example, the fractional coordinates of the 1st kpoint is
+adpt_kgrid.kvoxels[1].point
+# and the interpolated eigenvalues are
+adpt_kgrid.vals[1]
 
 # actual output is: `Fermi Energy after interpolation: 17.60847657 eV`
 @printf("Fermi Energy after interpolation: %.8f eV\n", εF)

--- a/docs/literate/examples/fermi_energy.jl
+++ b/docs/literate/examples/fermi_energy.jl
@@ -1,0 +1,60 @@
+# Use adaptive kmesh refinement to converge Fermi energy
+using Printf
+using LinearAlgebra
+using Wannier
+using Wannier.Datasets
+
+prefix = dataset"Fe_soc/reference/MDRS/Fe"
+tb = read_w90_tb(prefix)
+interp = HamiltonianInterpolator(tb.hamiltonian)
+
+lattice = real_lattice(interp)
+recip_lattice = reciprocal_lattice(lattice)
+kdistance = 0.08
+kgrid = round.(Int, [norm(b) for b in eachcol(recip_lattice)] ./ kdistance)
+
+kbT = 0.01  # eV
+# For NoneSmearing, usually need a larger tolerance, otherwise cannot bisect Fermi energy
+# smearing = Wannier.NoneSmearing()
+# tol_n_electrons = 1e-4
+# εF, adpt_kgrid = Wannier.compute_fermi_energy(interp, kgrid, num_electrons, kbT, smearing, tol_n_electrons)
+
+n_electrons = 8
+# This is a TB Hamiltonian from a SOC calculation
+prefactor = 1
+
+# smearing = Wannier.FermiDiracSmearing()
+smearing = Wannier.ColdSmearing()
+tol_εF = 5e-3  # convergence tolerance for Fermi energy in eV
+εF, adpt_kgrid = Wannier.compute_fermi_energy(
+    interp, kgrid, n_electrons, kbT, smearing; prefactor, tol_εF
+)
+
+# actual output is: `Fermi Energy after interpolation: 17.60847657 eV`
+@printf("Fermi Energy after interpolation: %.8f eV\n", εF)
+
+# As a comparison, the Fermi energy from pw.x scf calculation is 17.6132 eV,
+# which is computed on a 8x8x8 kgrid with 0.02 Ry cold smearing.
+
+using ProgressMeter
+# Compute n_electrons w.r.t. a range of Fermi energy
+εF_range = range(εF - 1, εF + 1; step=10e-3)
+n_electrons_range = @showprogress map(εF_range) do εi
+    occs = Wannier.occupation(adpt_kgrid, εi, kbT, smearing; prefactor)
+    kweights = Wannier.default_kweights(adpt_kgrid)
+    Wannier.compute_n_electrons(occs, kweights)
+end
+
+# find VBM, CBM
+vbm = Wannier.find_vbm(adpt_kgrid.vals, εF)[1]
+cbm = Wannier.find_cbm(adpt_kgrid.vals, εF)[1]
+
+using Plots
+plot(εF_range, n_electrons_range)
+xlabel!("Fermi energy (eV)")
+ylabel!("n_electrons")
+vline!([εF]; label="Fermi energy")
+vline!([vbm]; label="VBM")
+vline!([cbm]; label="CBM")
+xlims!(εF - 0.5, εF + 0.5)
+# gui()

--- a/test/interpolation/fermi_energy.jl
+++ b/test/interpolation/fermi_energy.jl
@@ -7,7 +7,7 @@
     interp = HamiltonianInterpolator(hamiltonian)
     kgrid = [12, 12, 12]
 
-    εF = Wannier.compute_fermi_energy(interp, kgrid, 7.1, 1e-2, Wannier.ColdSmearing())
+    εF = Wannier.compute_fermi_energy(kgrid, interp, 7.1, 1e-2, Wannier.ColdSmearing())
     εF_ref = 4.637512665199997
     @test isapprox(εF, εF_ref; atol=1e-3)
 end
@@ -22,7 +22,7 @@ end
     # a simple Fermi energy search would fail.
     kgrid = [5, 5, 1]
 
-    εF = Wannier.compute_fermi_energy(interp, kgrid, 8, 0, Wannier.NoneSmearing())
+    εF = Wannier.compute_fermi_energy(kgrid, interp, 8, 0, Wannier.NoneSmearing())
     εF_ref = -1.03673405699654
     @test isapprox(εF, εF_ref; atol=1e-3)
 end


### PR DESCRIPTION
Refactorization of #36, allow retrieving the interpolated kpoints and eigenvalues.