### PR TITLE
Reduce bvectors for Γ-point calculation

### DIFF
--- a/src/kpoints/kstencil.jl
+++ b/src/kpoints/kstencil.jl
@@ -451,6 +451,11 @@ function generate_kspace_stencil(
     shells = delete_shells(shells, keep_shells)
     shells.bweights .= bweights
 
+    # Γ-point calculation only keep half of the bvectors
+    if all(kgrid_size .== 1)
+        shells = delete_shells_Γ(shells)
+    end
+
     check_completeness(shells; atol)
     # generate bvectors for each kpoint
     return sort_bvectors(shells; atol)

--- a/src/kpoints/kstencil_shell.jl
+++ b/src/kpoints/kstencil_shell.jl
@@ -278,6 +278,27 @@ end
 """
     $(SIGNATURES)
 
+Delete negetive bvectors for Γ-point calculation.
+
+Since bvectors are symmetric, this removes half of the bvectors.
+"""
+function delete_shells_Γ(shells::KspaceStencilShells)
+    bvectors = map(shells.bvectors) do bvecs  # for each shell
+        bvecs_new = filter(v -> all(v .>= 0), bvecs)
+        if length(bvecs_new) != length(bvecs)//2
+            error("Non-symmetric bvectors for Γ-point calculation: ", bvecs)
+        end
+        bvecs_new
+    end
+    bweights = [2w for w in shells.bweights]
+    return KspaceStencilShells(
+        shells.recip_lattice, shells.kgrid_size, shells.kpoints, bvectors, bweights
+    )
+end
+
+"""
+    $(SIGNATURES)
+
 Try to guess bvector bweights from MV1997 Eq. (B1).
 
 The input bvectors are overcomplete vectors found during shell search, i.e., from

--- a/src/localization/gauge.jl
+++ b/src/localization/gauge.jl
@@ -133,25 +133,25 @@ function rotate_gauge!(model::Model, U::AbstractVector; ensure_bloch_gauge::Bool
 function transform_gauge(
     model::Model, U::Vector{Matrix{T}}; ensure_bloch_gauge::Bool=false
 ) where {T<:Number}
-    n_bands = model.n_bands
-    n_kpts = model.n_kpts
-    (size(U[1], 1), length(U)) == (n_bands, n_kpts) ||
-        error("U must have size (n_bands, :, n_kpts)")
+    nbands = n_bands(model)
+    nkpts = n_kpoints(model)
+    (size(U[1], 1), length(U)) == (nbands, nkpts) ||
+        error("inconsistent size between U and model")
     # The new n_wann
-    n_wann = size(U[1], 2)
+    nwann = size(U[1], 2)
 
     # the new gauge is just identity
-    U2 = identity_U(eltype(U[1]), n_kpts, n_wann)
+    U2 = identity_gauge(eltype(U[1]), nkpts, nwann)
 
     # EIG
-    E = model.E
+    E = model.eigenvalues
     E2 = map(m -> similar(m), E)
-    H = zeros(eltype(model.U[1]), n_wann, n_wann)
+    H = zeros(eltype(model.gauges[1]), nwann, nwann)
     # tolerance for checking Hamiltonian
     atol = 1e-8
     # all the diagonalized kpoints, used if diag_H = true
     diag_kpts = Int[]
-    for ik in 1:n_kpts
+    for ik in 1:nkpts
         Uₖ = U[ik]
         H .= Uₖ' * diagm(0 => E[ik]) * Uₖ
         ϵ = diag(H)
@@ -172,8 +172,8 @@ function transform_gauge(
     end
 
     # MMN
-    M = model.M
-    kpb_k = model.bvectors.kpb_k
+    M = model.overlaps
+    kpb_k = model.kstencil.kpb_k
     M2 = transform_gauge(M, kpb_k, U)
     if ensure_bloch_gauge && length(diag_kpts) > 0
         M2 = transform_gauge(M2, kpb_k, U2)
@@ -187,13 +187,11 @@ function transform_gauge(
         model.lattice,
         model.atom_positions,
         model.atom_labels,
-        model.kgrid_size,
-        model.kpoints,
-        model.bvectors,
-        [falses(n_wann) for i in 1:n_kpts],
+        model.kstencil,
         M2,
         U2,
         E2,
+        [falses(nwann) for i in 1:nkpts],
     )
     return model2
 end

--- a/src/localization/split.jl
+++ b/src/localization/split.jl
@@ -224,8 +224,8 @@ Split the `Model` into several `Model`s.
 function split_model(
     model::Model, eig_groups::AbstractVector{R}
 ) where {R<:AbstractVector{Int}}
-    E = model.E
-    U = model.U
+    E = model.eigenvalues
+    U = model.gauges
     EVs = split_eig(E, U, eig_groups)
 
     UVs = []
@@ -234,8 +234,8 @@ function split_model(
         UV = merge_gauge(U, EV[2])
         push!(UVs, UV)
 
-        m = rotate_gauge(model, UV)
-        @assert m.E ≈ EV[1]
+        m = transform_gauge(model, UV)
+        @assert m.eigenvalues ≈ EV[1]
         push!(models, m)
     end
 
@@ -281,7 +281,7 @@ function split_wannierize(
 
     for (model, _) in model_Us
         U, _ = parallel_transport(model)
-        model.U .= U
+        model.gauges .= U
     end
 
     return model_Us


### PR DESCRIPTION
W90 removes half of the bvectors, we do the same so as to read `mmn` file from `pw2wannier90`.