### PR TITLE
Fix filtering of bvectors for gamma only case

### DIFF
--- a/src/kpoints/kstencil_shell.jl
+++ b/src/kpoints/kstencil_shell.jl
@@ -284,7 +284,26 @@ Since bvectors are symmetric, this removes half of the bvectors.
 """
 function delete_shells_Γ(shells::KspaceStencilShells)
     bvectors = map(shells.bvectors) do bvecs  # for each shell
-        bvecs_new = filter(v -> all(v .>= 0), bvecs)
+        bvecs_new = empty(bvecs)
+        for b in bvecs
+            is_duplicate = false
+            
+            # Compare with vectors already in bvecs_new
+            for b_new in bvecs_new
+                # Check if b == -b_new
+                is_duplicate = sum((b .+ b_new).^2) == 0.0
+        
+                if is_duplicate
+                    break
+                end
+            end
+        
+            # Add the vector if it is not a duplicate
+            if !is_duplicate
+                push!(bvecs_new, b)
+            end
+        end
+
         if length(bvecs_new) != length(bvecs)//2
             error("Non-symmetric bvectors for Γ-point calculation: ", bvecs)
         end


### PR DESCRIPTION
Currently all positive bvectors are chosen while filtering bvectors in the `delete_shells_Γ` function. This won't work if some components are negative. For example, this does not work for the Na_chain in the wannier90 tests:
```
using Wannier
read_w90("test-suite/tests/testw90_na_chain_gamma/Na_chain")
```
gives the error:
```
┌ Info: Reading win file
│   filename = "test-suite/tests/testw90_na_chain_gamma/Na_chain.win"
│   num_wann = 10
│   num_bands = 30
└   mp_grid = (1, 1, 1)
ERROR: Non-symmetric bvectors for Γ-point calculation: StaticArraysCore.SVector{3, Float64}[[-0.20943951023931953, 0.0, -0.6283185307179586], [-0.20943951023931953, 0.6283185307179586, 0.0], [0.20943951023931953, 0.6283185307179586, 0.0], [0.20943951023931953, 0.0, 0.6283185307179586], [0.20943951023931953, -0.6283185307179586, 0.0], [0.20943951023931953, 0.0, -0.6283185307179586], [-0.20943951023931953, -0.6283185307179586, 0.0], [-0.20943951023931953, 0.0, 0.6283185307179586]]
```
I noticed this while I was testing it for a system I was working on.

I have fixed this by modifying the `delete_shells_Γ` to find the non-unique bvectors by  filtering bvectors based on whether they are negative of each other. Also, I had to sort the bvectors before `delete_shells_Γ` due to as I was getting an error:
```
ERROR: AssertionError: auto generated kpb_G are different from mmn file
```
otherwise. So I had to add a method `delete_shells_Γ(::KspaceStencil)` for the same. This does fix the issue and the above code works fine now. It might be useful to add the above case to the tests.

I am not familiar with the codebase and I am looking at the wannier code for the first time, so not sure whether this is the best approach. Let me know if any changes need to be made. 

Also, thanks for the great package :)